### PR TITLE
Poll-0006: Set up Jenkins server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM jenkins/jenkins:lts
+
+USER root
+
+RUN apt-get update && apt-get install -y git make
+
+USER jenkins

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Summary
 
-To start a Kong server with Konga (a 3rd party UI for Kong) locally,
+To spin up SurveyDonkey infrastructure,
 
 ```shell
 docker-compose up
@@ -8,10 +8,18 @@ docker-compose up
 
 This will start
 
-- a PostgreSQL container
-- a Kong server container
-- a Konga server container
-- necessary database migrations
+- Kong
+
+  - a PostgreSQL container
+  - a Kong server container
+  - a Konga server container
+  - necessary database migrations
+
+- Jenkins: with git and make installed
+
+- SonarQube
+
+- WebhookRelay: to allow application on internet (e.g. Github) send message to SurveyDonkey local containers (e.g. http://loalhost:8080) inside an intranet
 
 ![konga](konga.png)
 
@@ -32,3 +40,5 @@ To restart a container, e.g. konga
 ```shell
 docker-compose restart konga
 ```
+
+To set up Webhookrelay deliverying Github message to Jenkins, put the destination url as `http://jenkins:8080`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,8 +132,8 @@ services:
       - kong-net
 
   #Jenkins
-  Jenkins:
-    image: jenkins/jenkins:lts
+  jenkins:
+    build: .
     ports:
       - '8080:8080'
       - '50000:50000'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,3 +122,30 @@ services:
       - db
     ports:
       - '1337:1337'
+
+  #SonarQube
+  SonarQube:
+    image: sonarqube
+    ports:
+      - '9000:9000'
+    networks:
+      - kong-net
+
+  #Jenkins
+  Jenkins:
+    image: jenkins/jenkins:lts
+    ports:
+      - '8080:8080'
+      - '50000:50000'
+    networks:
+      - kong-net
+
+  #WebhookRelay
+  Relay:
+    image: webhookrelay/webhookrelayd
+    environment:
+      - KEY=4ec972c0-65b4-4f92-af91-d19c57b6ed82
+      - SECRET=IIe06wMZjc4W
+      - BUCKET=SurveyDonkey-Bucket
+    networks:
+      - kong-net


### PR DESCRIPTION
## Summary

This change adds a Jenkins service to SurveyDonkey infrastructure. 
- The Jenkins server is running on a docker container, with make and git installed.
- Job DSL plugin is required to enable creating jobs from job DSL

![image](https://user-images.githubusercontent.com/10679959/68068047-a79c1a00-fda4-11e9-84fe-0beee60fb420.png)


